### PR TITLE
added get_media_size(), bug fixes, more options sent to frontend

### DIFF
--- a/src/backend_helper.c
+++ b/src/backend_helper.c
@@ -1656,19 +1656,19 @@ char *get_human_readable_choice_name(const char *option_name, const char *choice
     if (strcmp("sides", option_name) == 0)
     {
         if (strcmp("one-sided", choice_name) == 0)
-            return get_string_copy("False");
+            return get_string_copy("Off");
         if (strcmp("two-sided-short-edge", choice_name) == 0)
-            return get_string_copy("True, Landscape");
+            return get_string_copy("On, Landscape");
         if (strcmp("two-sided-long-edge", choice_name) == 0)
-            return get_string_copy("True, Potrait");
+            return get_string_copy("On, Potrait");
     }
     if (strcmp("multiple-document-handling", option_name) == 0)
     {
         
         if (strcmp("separate-documents-uncollated-copies", choice_name) == 0)
-            return get_string_copy("False");
+            return get_string_copy("Off");
         if (strcmp("separate-documents-collated-copies", choice_name) == 0)
-            return get_string_copy("True");
+            return get_string_copy("On");
     }
     if (strcmp("media", option_name) == 0)
     {
@@ -1681,9 +1681,9 @@ char *get_human_readable_choice_name(const char *option_name, const char *choice
     if (strcmp("page-delivery", option_name) == 0)
     {
         if (strcmp("same-order", choice_name) == 0)
-            return get_string_copy("False");
+            return get_string_copy("Off");
         if (strcmp("reverse-order", choice_name) == 0)
-            return get_string_copy("True");
+            return get_string_copy("On");
     }
     if (strcmp("page-border", option_name) == 0)
     {

--- a/src/backend_helper.h
+++ b/src/backend_helper.h
@@ -197,6 +197,11 @@ char *get_human_readable_option_name(const char *option_name);
  */
 char *get_human_readable_choice_name(const char *option_name, const char *choice_name);
 
+/**
+ * Get media dimensions for given size.
+ */
+void get_media_size(const char *media, int *width, int *height);
+
 void tryPPD(PrinterCUPS *p);
 /**********Dialog related funtions ****************/
 Dialog *get_new_Dialog();

--- a/src/print_backend_cups.c
+++ b/src/print_backend_cups.c
@@ -249,10 +249,10 @@ static gboolean on_handle_get_human_readable_option_name(PrintBackend *interface
                                                          const gchar *option_name,
                                                          gpointer user_data)
 {
-  char *human_readable_name = get_human_readable_option_name(option_name);
-  printf("Human readable name of option %s is %s\n", option_name, human_readable_name);
-  print_backend_complete_get_human_readable_option_name(interface, invocation, human_readable_name);
-  return TRUE;
+    char *human_readable_name = get_human_readable_option_name(option_name);
+    printf("Human readable name of option %s is %s\n", option_name, human_readable_name);
+    print_backend_complete_get_human_readable_option_name(interface, invocation, human_readable_name);
+    return TRUE;
 }
 
 static gboolean on_handle_get_human_readable_choice_name(PrintBackend *interface,
@@ -262,11 +262,24 @@ static gboolean on_handle_get_human_readable_choice_name(PrintBackend *interface
                                                          gpointer user_data)
 {
     char *human_readable_name = get_human_readable_choice_name(option_name, choice_name);
-    printf("Human readable name of choice %s for option %s is %s", choice_name, option_name, human_readable_name);
+    printf("Human readable name of choice %s for option %s is %s\n", choice_name, option_name, human_readable_name);
     print_backend_complete_get_human_readable_choice_name(interface, invocation, human_readable_name);
     return TRUE;
 }
 
+static gboolean on_handle_get_media_size(PrintBackend *interface,
+                                         GDBusMethodInvocation *invocation,
+                                         const gchar *media,
+                                         gpointer user_data)
+{
+    int width, length;
+    GVariant *variant;
+
+    get_media_size(media, &width, &length);
+    variant = g_variant_new ("(ii)", width, length);
+    print_backend_complete_get_media_size(interface, invocation, variant);
+    return TRUE;
+}
 
 static gboolean on_handle_ping(PrintBackend *interface,
                                GDBusMethodInvocation *invocation,
@@ -467,6 +480,10 @@ void connect_to_signals()
                      "handle-get-human-readable-choice-name",              //instance
                      G_CALLBACK(on_handle_get_human_readable_choice_name), // signal name
                      NULL);                                                // callback
+    g_signal_connect(skeleton,
+                     "handle-get-media-size",              //instance
+                     G_CALLBACK(on_handle_get_media_size), // signal name
+                     NULL);                                // callback
     g_dbus_connection_signal_subscribe(b->dbus_connection,
                                        NULL,                             //Sender name
                                        "org.openprinting.PrintFrontend", //Sender interface


### PR DESCRIPTION
Adds the following to cpdb-backend-cups:
- added media-margins and media-ranges option sent by the backend to frontend
- added get_media_size() to get dimensions of a given media
- updated dest of printers after materialization of CUPS queue, which caused a bug
- other bug fixes