### PR TITLE
add groups & translations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,12 +14,13 @@ AC_PROG_CC
 
 # Checks for backend library 
 PKG_CHECK_MODULES([CPDB],[cpdb >= 2])
+PKG_CHECK_MODULES([LIBCUPSFILTERS], [libcupsfilters >= 2])
 PKG_CHECK_MODULES([GIO],[gio-2.0])
 PKG_CHECK_MODULES([GIOUNIX],[gio-unix-2.0])
 PKG_CHECK_MODULES([GLIB],[glib-2.0])
 
 # Checks for header files.
-AC_CHECK_HEADERS([stdlib.h string.h cups/cups.h])
+AC_CHECK_HEADERS([stdlib.h string.h cups/cups.h cupsfilters/catalog.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_TYPE_SIZE_T

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,12 +2,14 @@ backenddir = $(CPDB_BACKEND_DIR)
 backend_PROGRAMS = cups
 cups_SOURCES = print_backend_cups.c backend_helper.c backend_helper.h
 cups_CPPFLAGS  = $(CPDB_CFLAGS)
+cups_CPPFLAGS += $(LIBCUPSFILTERS_CFLAGS)
 cups_CPPFLAGS += $(GLIB_CFLAGS)
 cups_CPPFLAGS += $(GIO_CFLAGS)
 cups_CPPFLAGS += $(GIOUNIX_CFLAGS)
 
-cups_LDADD  =  $(CPDB_LIBS)
-cups_LDADD += -lcups -lpthread -lm -lcrypt
+cups_LDADD  = -lcups -lpthread -lm -lcrypt
+cups_LDADD += $(CPDB_LIBS)
+cups_LDADD += $(LIBCUPSFILTERS_LIBS)
 cups_LDADD += $(GLIB_LIBS)
 cups_LDADD += $(GIO_LIBS)
 cups_LDADD += $(GIOUNIX_LIBS)

--- a/src/backend_helper.h
+++ b/src/backend_helper.h
@@ -5,9 +5,12 @@
 #include <stdlib.h>
 #include <glib.h>
 #include <string.h>
+
 #include <cups/cups.h>
 #include <cups/ppd.h>
-#include <cpdb/cpdb.h>
+#include <cupsfilters/catalog.h>
+
+#include <cpdb/backend.h>
 
 #define INFO 3
 #define WARN 2
@@ -200,6 +203,18 @@ int print_file(PrinterCUPS *p, const char *file_path, int num_settings, GVariant
 
 int get_active_jobs_count(PrinterCUPS *p);
 gboolean cancel_job(PrinterCUPS *p, int jobid);
+
+/**
+ * Get translation of choice name for a given locale
+ */
+char *get_option_translation(PrinterCUPS *p, const char *option_name,
+                             const char *locale);
+
+/**
+ * Get translation of option name for a given locale
+ */
+char *get_choice_translation(PrinterCUPS *p, const char *option_name,
+                             const char *choice_name, const char *locale);
 
 /**
  * Get human readable names of the options.


### PR DESCRIPTION
Added:
 - dependency `libcupsfilters`
 - translations handler functions

CUPS backend now uses `cupsfilter/catalog.h` for getting option & choice translations, and `cpdb/backend.h` for getting group translations