### PR TITLE
Always query current CUPS default printer

### DIFF
--- a/src/backend_helper.c
+++ b/src/backend_helper.c
@@ -35,12 +35,6 @@ BackendObj *get_new_BackendObj()
 /** Don't free the returned value; it is owned by BackendObj */
 char *get_default_printer(BackendObj *b)
 {
-    /** If it was  previously querie, don't query again */
-    if (b->default_printer)
-    {
-        return b->default_printer;
-    }
-
     /**first query to see if the user default printer is set**/
     int num_dests;
     cups_dest_t *dests;
@@ -51,6 +45,7 @@ char *get_default_printer(BackendObj *b)
         /** Return the user default printer */
         char *def = g_strdup(dest->name);
         cupsFreeDests(num_dests, dests);
+        g_free(b->default_printer);
         b->default_printer = def;
         return def;
     }
@@ -65,12 +60,14 @@ char *get_default_printer(BackendObj *b)
         if ((attr = ippFindAttribute(response, "printer-name",
                                      IPP_TAG_NAME)) != NULL)
         {
+            g_free(b->default_printer);
             b->default_printer = g_strdup(ippGetString(attr, 0, NULL));
             ippDelete(response);
             return b->default_printer;
         }
     }
     ippDelete(response);
+    g_free(b->default_printer);
     b->default_printer = g_strdup("NA");
     return b->default_printer;
 }


### PR DESCRIPTION
When asked for the default printer, always
query and return the current CUPS default
printer instead of whatever was the default
last time this was done, to take into account
that the CUPS default printer can change while
the backend is running.

Sample steps (without this commit in place)
to reproduce an incorrect default
printer being returned with cpdb-text-frontend
from cpdb-libs, when the PDF printer is initially
set as default:

Run cpdb-text-frontend:

    $ cpdb-text-frontend

Query for the default printer

    > get-default-printer
    PDF#CUPS

Now, switch the CUPS user default printer
to another one:

    $ lpoptions -d somedummy

In the running cpdb-text-frontend instance,
query the default printer again:

    > get-default-printer
    PDF#CUPS

-> The outdated/previous default printer was returned.

With this commit in place, the new default
printer is now returned as expected:

    > get-default-printer
    somedummy#CUPS

(This addresses part of issue 3) from comment [1] on the pending change to update CPDB support in LibreOffice.)

[1] https://gerrit.libreoffice.org/c/core/+/169617/comments/3ef76e40_4f120b66