### PR TITLE
Add support for CUPS printer instances

### DIFF
--- a/src/backend_helper.h
+++ b/src/backend_helper.h
@@ -117,6 +117,11 @@ typedef struct _AddressList {
 
 /********Backend related functions*******************/
 
+/** Get a printer name for a CUPS destination.
+ * This takes into account the destinations instance name, if any.
+ */
+char *get_printer_name_for_cups_dest(const cups_dest_t *dest);
+
 /** Get a new BackendObj **/
 BackendObj *get_new_BackendObj();
 

--- a/src/print_backend_cups.c
+++ b/src/print_backend_cups.c
@@ -206,9 +206,11 @@ static gboolean on_handle_get_all_printers(PrintBackend *interface,
         accepting_jobs = cups_is_accepting_jobs(dest);
         state = cups_printer_state(dest);
         add_printer_to_dialog(b, dialog_name, dest);
-        printer = g_variant_new(CPDB_PRINTER_ARGS, dest->name, dest->name, info,
+        char *printer_name = get_printer_name_for_cups_dest(dest);
+        printer = g_variant_new(CPDB_PRINTER_ARGS, printer_name, printer_name, info,
                                 location, make, accepting_jobs, state, BACKEND_NAME);
         g_variant_builder_add(&builder, "(v)", printer);
+        g_free(printer_name);
         free(key);
         cupsFreeDests(1, value);
         free(info);
@@ -262,9 +264,11 @@ static gboolean on_handle_get_filtered_printer_list(PrintBackend *interface,
         accepting_jobs = cups_is_accepting_jobs(dest);
         state = cups_printer_state(dest);
         add_printer_to_dialog(b, dialog_name, dest);
-        printer = g_variant_new(CPDB_PRINTER_ARGS, dest->name, dest->name, info,
+        char *printer_name = get_printer_name_for_cups_dest(dest);
+        printer = g_variant_new(CPDB_PRINTER_ARGS, printer_name, printer_name, info,
                                 location, make, accepting_jobs, state, BACKEND_NAME);
         g_variant_builder_add(&builder, "(v)", printer);
+        g_free(printer_name);
         free(key);
         cupsFreeDests(1, value);
         free(info);
@@ -318,7 +322,7 @@ int send_printer_added(void *_dialog_name, unsigned flags, cups_dest_t *dest)
 {
 
     const char *dialog_name = (const char *)_dialog_name;
-    char *printer_name = dest->name;
+    char *printer_name = get_printer_name_for_cups_dest(dest);
 
     if (dialog_contains_printer(b, dialog_name, printer_name))
     {
@@ -329,6 +333,8 @@ int send_printer_added(void *_dialog_name, unsigned flags, cups_dest_t *dest)
     add_printer_to_dialog(b, dialog_name, dest);
     send_printer_added_signal(b, dialog_name, dest);
     g_message("     Sent notification for printer %s\n", printer_name);
+
+    g_free(printer_name);
 
     /** dest will be automatically freed later. 
      * Don't explicitly free it


### PR DESCRIPTION
Don't just always use the `cups_dest_t`'s `name`
for the printer name, but also take it's `instance` member into account and if present, append that for the name used for the CPDB printer name, separated by a slash character.

Since `PrinterCUPS::name` is now assigned a newly
allocated string in `get_new_PrinterCUPS`, free
it again in `free_PrinterCUPS`.

While previously, CUPS printers instances were not available at all, they are now presented as separate printers.

For example, if there's a PDF printer, a printer instance with a different default resolution can be created using

    lpoptions -p PDF/someinstance -o Resolution=1200dpi

and a `PDF/someinstance` printer now also shows up in `cpdb-text-frontend` from cpdb-libs, while it
wasn't without this commit in place.

FWIW, the modified default value for the
option as set above currently doesn't show up with cpdb-libs git master as of commit cc51ac3c48c9e5cede90aaedb13dc1333bde3b60 when using the

    get-all-options PDF/someinstance CUPS

command, but the same is true when changing a default value for the default instance, i.e. using

    lpoptions -p PDF -o Resolution=1200dpi

, so this seems to be a separate issue and unrelated to the added CUPS printer instance support.