### PR TITLE
Use NULL Instead of "NA" if there's no default printer

### DIFF
--- a/src/backend_helper.c
+++ b/src/backend_helper.c
@@ -79,7 +79,7 @@ char *get_default_printer(BackendObj *b)
     }
     ippDelete(response);
     g_free(b->default_printer);
-    b->default_printer = g_strdup("NA");
+    b->default_printer = NULL;
     return b->default_printer;
 }
 


### PR DESCRIPTION
NULL makes clear that there's no default printer, while "NA" could even be the name of an actual printer, so use the former instead of the latter if no default printer could be determined.

See also discussion in [1] where this preexisting
issue was spotted.

[1] https://github.com/OpenPrinting/cpdb-backend-cups/pull/33#discussion_r1703699309