### PR TITLE
Fix acquire_session_bus_name prototype (and GCC 15 build)

### DIFF
--- a/src/print_backend_cups.c
+++ b/src/print_backend_cups.c
@@ -17,7 +17,7 @@ static void
 on_name_acquired(GDBusConnection *connection,
                  const gchar *name,
                  gpointer not_used);
-static void acquire_session_bus_name();
+static void acquire_session_bus_name(char *bus_name);
 gpointer list_printers(gpointer _dialog_name);
 int send_printer_added(void *_dialog_name, unsigned flags, cups_dest_t *dest);
 void connect_to_signals();


### PR DESCRIPTION
With GCC 15.2.0 on Debian testing, the build would fail as follows, due to the acquire_session_bus_name prototype not matching the actual function that
takes a char* param:

    print_backend_cups.c: In function ‘main’:
    print_backend_cups.c:101:5: error: too many arguments to function ‘acquire_session_bus_name’; expected 0, have 1
      101 |     acquire_session_bus_name(BUS_NAME);
          |     ^~~~~~~~~~~~~~~~~~~~~~~~
    print_backend_cups.c:20:13: note: declared here
       20 | static void acquire_session_bus_name();
          |             ^~~~~~~~~~~~~~~~~~~~~~~~
    print_backend_cups.c: At top level:
    print_backend_cups.c:146:13: error: conflicting types for ‘acquire_session_bus_name’; have ‘void(char *)’
      146 | static void acquire_session_bus_name(char *bus_name)
          |             ^~~~~~~~~~~~~~~~~~~~~~~~
    print_backend_cups.c:20:13: note: previous declaration of ‘acquire_session_bus_name’ with type ‘void(void)’
       20 | static void acquire_session_bus_name();
          |             ^~~~~~~~~~~~~~~~~~~~~~~~
    print_backend_cups.c:20:13: warning: ‘acquire_session_bus_name’ used but never defined

Fix that.

Fixes: #40