### PR TITLE
Range-check printer-state before indexing state map (OCU-01-005)

### DIFF
--- a/src/backend_helper.c
+++ b/src/backend_helper.c
@@ -1424,8 +1424,12 @@ const char *get_printer_state(PrinterCUPS *p)
     if ((attr = ippFindAttribute(response, "printer-state",
                                  IPP_TAG_ENUM)) != NULL)
     {
-        logdebug("printer-state=%d\n", ippGetInteger(attr, 0));
-        str = map->state[ippGetInteger(attr, 0)];
+        int state = ippGetInteger(attr, 0);
+        logdebug("printer-state=%d\n", state);
+        if (state >= 0 && state < 6)
+            str = map->state[state];
+        else
+            str = "NA";
     }
     return str;
 }
@@ -1868,6 +1872,8 @@ void free_Dialog(Dialog *d)
 Mappings *get_new_Mappings()
 {
     Mappings *m = (Mappings *)(malloc(sizeof(Mappings)));
+    for (int i = 0; i < 6; i ++)
+        m->state[i] = "NA";
     m->state[3] = CPDB_STATE_IDLE;
     m->state[4] = CPDB_STATE_PRINTING;
     m->state[5] = CPDB_STATE_STOPPED;
@@ -1886,7 +1892,10 @@ const char *cups_printer_state(cups_dest_t *dest)
                                       dest->options);
     if (state == NULL)
         return "NA";
-    return map->state[state[0] - '0'];
+    int idx = state[0] - '0';
+    if (idx < 0 || idx >= 6)
+        return "NA";
+    return map->state[idx];
 }
 
 gboolean cups_is_accepting_jobs(cups_dest_t *dest)


### PR DESCRIPTION
### What this fixes

Fixes #68 (audit finding OCU-01-005).

`get_printer_state()` in `src/backend_helper.c` reads the printer's `printer-state` as an IPP enum and uses the raw value directly as an index into `map->state[]`. That array has six entries and only indices 3–5 are ever set, so an out-of-range value from an untrusted printer reads past the end of the array or into an uninitialised entry — crashing the backend. The value is checked to be an enum but never range-checked.

`cups_printer_state()` in the same file has the same pattern with `map->state[state[0] - '0']`, indexed from a CUPS option string without a range check.

### The fix

- Range-check the state value in `get_printer_state()` and fall back to `"NA"` for anything outside the valid range.
- Apply the same guard in `cups_printer_state()`.
- Initialise all six `state[]` entries to `"NA"` in `get_new_Mappings()`, so no lookup can land on an uninitialised slot.

`"NA"` is already the function's existing fallback for a failed request, so unknown states now return that instead of crashing.