### PR TITLE
Fix unmatched cppcheck suppression

### DIFF
--- a/src/test_extractHostFromURI.c
+++ b/src/test_extractHostFromURI.c
@@ -9,8 +9,6 @@
 #include "test-internal.h"
 #include "backend_helper.h"
 
-// cppcheck-suppress nullPointerRedundantCheck // free(NULL) is valid; test verifies NULL return
-
 // Test extractHostFromURI function
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
Removes the unmatched // cppcheck-suppress nullPointerRedundantCheck that was added at the top of test_extractHostFromURI.c in 62a9d67.

cppcheck says it's unmatched and the file at bb64605 has no such finding — the if (host) free(host) pattern isn't flagged. Probably confused with a different repo's finding. Just removing dead comment, no logic change.

Verified with cppcheck --enable=all --inline-suppr before/after — no new findings.